### PR TITLE
Remove TC and other dependencies which conflicts with actuator-ui plugin tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,11 @@ dependencyManagement {
 }
 
 dependencies {
-    compile "org.springframework.boot:spring-boot-starter-logging"
-    compile "org.springframework.boot:spring-boot-autoconfigure"
+    provided "org.springframework.boot:spring-boot-starter-logging"
+    provided "org.springframework.boot:spring-boot-autoconfigure"
     compile "org.grails:grails-core"
-    compile "org.springframework.boot:spring-boot-starter-actuator"
-    compile "org.springframework.boot:spring-boot-starter-tomcat"
+    provided "org.springframework.boot:spring-boot-starter-actuator"
+    provided "org.springframework.boot:spring-boot-starter-tomcat"
     compile "org.grails:grails-dependencies"
     compile "org.grails:grails-web-boot"
     compile "org.grails.plugins:scaffolding"


### PR DESCRIPTION
It is a good idea to change the configuration to `provided` instead of `compile` for spring boot starter dependencies in grails plugins.

This would possibly fix the [Travis CI tests for actuator-ui for JDK 7](https://travis-ci.org/dmahapatro/grails-actuator-ui/jobs/157374442). It got fixed for me when tested locally. 

Did not increment the version. Please release the newest version which we can refer  in actuator-ui plugin.
